### PR TITLE
Add translations and minor punctuation corrections to the Spanish file

### DIFF
--- a/es-ES/strings.po
+++ b/es-ES/strings.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: klei-accounts\n"
 "Report-Msgid-Bugs-To: support@kleientertainment.com\n"
 "POT-Creation-Date: 2018-05-24 11:14-0700\n"
-"PO-Revision-Date: 2021-10-15 08:23-0700\n"
+"PO-Revision-Date: 2021-10-15 08:26-0700\n"
 "Last-Translator: Klei Entertainment <support@kleientertainment.com>\n"
 "Language-Team: Spanish (https://accounts.klei.com/community-translations)\n"
 "Language: es\n"
@@ -75,7 +75,7 @@ msgstr "Juegos"
 
 #. i18n: keyword: Betas
 msgid "Betas"
-msgstr ""
+msgstr "Betas"
 
 #. i18n: keyword: Language
 msgid "Language"
@@ -839,7 +839,7 @@ msgstr "Estilo de Juego del Servidor"
 
 #. i18n: keyword: ConfigureServerPlaystyleSocial
 msgid "Social"
-msgstr ""
+msgstr "Social"
 
 #. i18n: keyword: ConfigureServerPlaystyleCooperative
 msgid "Cooperative"
@@ -995,19 +995,19 @@ msgstr "<b>Bolts de Ropa</b> - (Solamente en Consola) Es una moneda dentro del j
 
 #. i18n: keyword: RewardPointsAbbreviation
 msgid "pts"
-msgstr ""
+msgstr "pts"
 
 #. i18n: keyword: RewardBoltsAbbreviation
 msgid "bolts"
-msgstr ""
+msgstr "bolts"
 
 #. i18n: keyword: RewardSpoolsAbbreviation
 msgid "spools"
-msgstr ""
+msgstr "spools"
 
 #. i18n: keyword: RewardPointsMinutes
 msgid "min"
-msgstr ""
+msgstr "min"
 
 #. i18n: keyword: RewardBalance
 msgid "Current Balance"
@@ -1135,23 +1135,23 @@ msgstr "El token usado para reclamar el código de regalo tiene un propósito di
 
 #. i18n: keyword: Facebook
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #. i18n: keyword: Instagram
 msgid "Instagram"
-msgstr ""
+msgstr "Instagram"
 
 #. i18n: keyword: Twitch
 msgid "Twitch"
-msgstr ""
+msgstr "Twitch"
 
 #. i18n: keyword: Douyu
 msgid "Douyu"
-msgstr ""
+msgstr "Douyu"
 
 #. i18n: keyword: Bilibili
 msgid "Bilibili"
-msgstr ""
+msgstr "Bilibili"
 
 #. i18n: keyword: SupportTitle
 msgid "Submit a Support Request"
@@ -1239,7 +1239,7 @@ msgstr "Correo electrónico no válido. Comprueba que la dirección de correo qu
 
 #. i18n: keyword: Error
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #. i18n: keyword: NewAccount
 msgid "Create A New Account"
@@ -1295,7 +1295,7 @@ msgstr "Al registrarte, aceptas nuestra <a href='https://www.kleientertainment.c
 
 #. i18n: keyword: KleiEntertainment
 msgid "Klei Entertainment"
-msgstr ""
+msgstr "Klei Entertainment"
 
 #. i18n: keyword: ErrorURLMalformed
 msgid "The URL you used to arrive here is malformed and missing required parameters."

--- a/es-ES/strings.po
+++ b/es-ES/strings.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: klei-accounts\n"
 "Report-Msgid-Bugs-To: support@kleientertainment.com\n"
 "POT-Creation-Date: 2018-05-24 11:14-0700\n"
-"PO-Revision-Date: 2020-07-24 03:24\n"
+"PO-Revision-Date: 2021-10-15 08:17-0700\n"
 "Last-Translator: Klei Entertainment <support@kleientertainment.com>\n"
 "Language-Team: Spanish (https://accounts.klei.com/community-translations)\n"
 "Language: es\n"
@@ -427,7 +427,7 @@ msgstr "Este proceso permitirá que una cuenta de Klei sea asociada a multiples 
 
 #. i18n: keyword: MergeAccountConsent
 msgid "Please click the checkmark to confirm that you have read and understand the following."
-msgstr "Por favor, haz clic en la casilla para confirmar que haz leido y entendido lo siguiente"
+msgstr "Por favor, haz clic en la casilla para confirmar que haz leido y entendido lo siguiente."
 
 #. i18n: keyword: MergeAccountOptions
 msgid "Consent questions"
@@ -495,7 +495,7 @@ msgstr "Consentimiento de usuario invalido, necesitas leer las instrucciones par
 
 #. i18n: keyword: E_ACCOUNT_MERGE_MISSING_DATA
 msgid "It is impossible to merge your accounts right now because some data is missing. Please log out and start the process again. Make sure that your web browser accepts cookies and the two accounts you are going to merge are correct."
-msgstr "Es imposible fusionar tus cuentas ahora porque faltan algunos datos. Por favor cierra sesión y comienza el proceso de nuevo. Asegurate de que tu navegador acepta cookies y de que las dos cuentas que vas a fusionar sean correctas. "
+msgstr "Es imposible fusionar tus cuentas ahora porque faltan algunos datos. Por favor cierra sesión y comienza el proceso de nuevo. Asegúrate de que tu navegador acepta cookies y de que las dos cuentas que vas a fusionar sean correctas."
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_DIFFERENT_EMAIL
 msgid "Please update your *Klei* accounts to use the same e-mail address and start the process again."
@@ -503,11 +503,11 @@ msgstr "Por favor actualiza tus cuentas de *Klei* para usar el mismo correo y co
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_EMAIL_NOT_VALIDATED
 msgid "Please verify/validate the e-mail address in both accounts and start the process again."
-msgstr "Por favor verifica/valida que la dirección de correo electronico en ambas cuentas y comienza el proceso de nuevo"
+msgstr "Por favor verifica/valida la dirección de correo electrónico en ambas cuentas y comienza el proceso de nuevo."
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_BANNED
 msgid "We cannot merge your accounts because one of them is banned."
-msgstr "No podemos fusionar tus cuentas porque una de ellas está suspendida"
+msgstr "No podemos fusionar tus cuentas porque una de ellas está suspendida."
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_PASSWORD_RESET
 msgid "It appears your password was reset some time ago but you never finished the verification process."
@@ -515,11 +515,11 @@ msgstr "Parece que tu contraseña fue restableecida hace un tiempo pero tu nunca
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_MARKED_FOR_DELETION
 msgid "We cannot merge your accounts because one of them is marked for deletion."
-msgstr "No podemos fusionar tus cuentas porque una de ellas está marcada para eliminarse"
+msgstr "No podemos fusionar tus cuentas porque una de ellas está marcada para eliminarse."
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_NOTHING_TO_MERGE
 msgid "There is nothing to merge for this account."
-msgstr "No hay nada que unir en esta cuenta"
+msgstr "No hay nada para unificar en esta cuenta."
 
 #. i18n: keyword: E_ACCOUNT_MERGE_WARNING_PLATFORM_CONFLICT_klei.EpicID
 msgid "You already merged your Epic Games account."
@@ -647,7 +647,7 @@ msgstr "Por favor escriba “delete my account” en letras mayúsculas, para co
 
 #. i18n: keyword: DeleteAccountReason
 msgid "Please explain the reason for the account deletion:"
-msgstr "Por favor explica la razón para la eliminación de la cuenta."
+msgstr "Por favor explica la razón para la eliminación de la cuenta:"
 
 #. i18n: keyword: DeleteAccountButton
 msgid "I understand the consequences, delete this account"
@@ -683,7 +683,7 @@ msgstr "Podemos organizar un informe de los detalles de tu cuenta controlados po
 
 #. i18n: keyword: E_EXPORT_DATA_RECENTLY_USED
 msgid "It appears that you already downloaded your data less than 24 hours ago.<br><br>Please wait until tomorrow to download another copy of your data.<br><br>We appreciate your patience."
-msgstr "Parece que ya has descargado tus datos hace menos de 24 horas.<br><br>Por favor espera hasta mañana para descargar otra copia de tus datos.<br><br>"
+msgstr "Parece que ya has descargado tus datos hace menos de 24 horas.<br><br>Por favor espera hasta mañana para descargar otra copia de tus datos.<br><br>Nosotros apreciamos tu paciencia."
 
 #. i18n: keyword: DownloadData
 msgid "Download Data"
@@ -727,7 +727,7 @@ msgstr "Usted puede obtener una copia de este juego libre de DRM (Gestión de De
 
 #. i18n: keyword: E_DRM_KEYS_NO_GAMES
 msgid "Error: You do not seem to own any elegible games."
-msgstr "Error: No pareces tener ningun juego elegible"
+msgstr "Error: Tu no pareces tener juegos elegibles."
 
 #. i18n: keyword: DontStarveTogetherServers
 msgid "Game Servers"
@@ -871,11 +871,11 @@ msgstr "Tu inventario de objetos"
 
 #. i18n: keyword: ItemsDialogRarity
 msgid "Rarity:"
-msgstr "Rareza"
+msgstr "Rareza:"
 
 #. i18n: keyword: ItemsDialogRedeemed
 msgid "Redeemed:"
-msgstr "Canjeado"
+msgstr "Canjeado:"
 
 #. i18n: keyword: ItemsFilterRarity
 msgid "Rarity"
@@ -1367,7 +1367,7 @@ msgstr "La sesión ha expirado, debes iniciar sesión nuevamente. <b>¿Estás us
 
 #. i18n: keyword: E_STEAM_SERVICE_UNAVAILABLE
 msgid "The Steam service is unavailable."
-msgstr "El servicio de Steam no está disponible"
+msgstr "El servicio de Steam no está disponible."
 
 #. i18n: keyword: E_INVALID_STEAM_REQUEST
 msgid "Fail to authenticate your Steam account without an Internet connection."
@@ -1579,7 +1579,7 @@ msgstr "Los servidores de Steam están actualmente desconectados."
 
 #. i18n: keyword: E_STEAM_INVALID_RETURN_TO
 msgid "Steam redirected you to the incorrect URL, we cannot validate your credentials here. Please clear your web browser cache and cookies, and try to login one more time. If you require further assistance please <a href='http://support.klei.com/' target='blank_' rel='noopener noreferrer'>contact support</a>."
-msgstr "Steam te ha redirigido a un URL incorrecto, no podemos validar tus credenciales aquí. Porf favor borra el cache y cookies de tu navegador, e intenta iniciar sesión una vez mas. Si necesitas asistencia por favor <a href='http://support.klei.com/' target='blank_' rel='noopener noreferrer'>contacta a soporte</a>"
+msgstr "Steam te ha redirigido a una página incorrecta, no podemos validar tus credenciales aquí. Por favor borra el cache y cookies de tu navegador, e intenta iniciar sesión una vez mas. Si necesitas asistencia por favor <a href='http://support.klei.com/' target='blank_' rel='noopener noreferrer'>contacta a soporte</a>."
 
 #. i18n: keyword: E_STEAM_PLAYER_SUMMARY_FORBIDDEN
 msgid "Steam prevented us from showing your profile information."
@@ -1619,7 +1619,7 @@ msgstr "El sitio web anterior nos envió datos invalidos. La firma de la solicit
 
 #. i18n: keyword: E_OPENID_ACCESS_DENIED
 msgid "Steam denied your login attempt. Steam servers may be offline, which usually causes problems with Klei Entertainment and Steam's communication bridge. Please, wait a couple of minutes and try again. If the problem persists, feel free to send a message to our <a href='https://support.klei.com/'>support team</a>."
-msgstr "Steam ha denegado tu intento de inicio de sesión. Los servidores de Steam pueden estar offline, lo cual usualmente causa problemas con el puente de comuncación de Klei Entertainment y Steam. Por favor, espera unos minutos e intenta de nuevo. Si el problema persiste, sientente libre de enviarnos un mensaje a nuestro <a href='https://support.klei.com/'>equipo de soporte</a>. "
+msgstr "Steam ha denegado tu intento de inicio de sesión. Los servidores de Steam pueden estar fuera de línea, lo cual usualmente causa problemas con el puente de comunicación de Klei Entertainment y Steam. Por favor, espera unos minutos e intenta de nuevo. Si el problema persiste, siéntente libre de enviar un mensaje a nuestro <a href='https://support.klei.com/'>equipo de soporte</a>."
 
 #. i18n: keyword: E_STEAM_ID_IS_MISSING
 msgid "Steam identifier is missing. The game client did not provide all the information we need to authenticate your account. Please close the game and start again."
@@ -1639,7 +1639,7 @@ msgstr "El ticket de Tencent Games es invalido. El cliente del juego no proporci
 
 #. i18n: keyword: E_RAIL_EXPIRED_TOKEN
 msgid "The access token has expired. Tencent is asking you to start the process again."
-msgstr "El token de acceso ha expirado. Tencent está pidiendo que empieces el proceso de nuevo"
+msgstr "El token de acceso ha expirado. Tencent está pidiendo que empieces el proceso de nuevo."
 
 #. i18n: keyword: E_RAIL_GATEWAY_TIMEOUT
 msgid "Tencent’s user authentication service is not available right now. Please <a href='/login'>try again</a> in a few minutes."
@@ -1683,7 +1683,7 @@ msgstr "El código de verificación es inválido."
 
 #. i18n: keyword: E_INVALID_AUTH_PROVIDER
 msgid "The authorization provider was not detected. Please check if your web browser accepts cookies from this website, then go to the “Login” page and try one more time."
-msgstr "El proveedor de autorización no fue detectado. Por favor verifica si tu navegador acepta cookies de este sitio, después de eso ve a la página de “Inicio de Sesión” e intenta una vez mas. "
+msgstr "El proveedor de autorización no fue detectado. Por favor verifica si tu navegador acepta cookies de este sitio, después de eso ve a la página de “Inicio de Sesión” e intenta una vez mas."
 
 #. i18n: keyword: E_CLIENT_TOKEN_HAS_EXPIRED
 msgid "Client login token has expired."
@@ -1723,7 +1723,7 @@ msgstr "Un error inesperado ha ocurrido en Facebook. Por favor reintenta tu soli
 
 #. i18n: keyword: E_FACEBOOK_CHECKPOINT_BLOCK
 msgid "Facebook stopped the process because there is an error validating access token: The user is enrolled in a blocking, logged-in checkpoint."
-msgstr "Facebook detuvo el proceso debido a que hay un error validando el token de acceso: El usuario está inscrito en un punto de control de bloqueo e inicio de sesión. "
+msgstr "Facebook detuvo el proceso debido a que hay un error validando el token de acceso: El usuario está inscrito en un punto de control de bloqueo e inicio de sesión."
 
 #. i18n: keyword: E_EPIC_GAMES_EXPIRED_TOKEN
 msgid "Unfortunately, the token we use to communicate with Epic Games has expired. You will need to login again to allow the system to get a new token."
@@ -1791,7 +1791,7 @@ msgstr "Cantidad de Puntos Actuales"
 
 #. i18n: keyword: NewBalance
 msgid "New Balance:"
-msgstr "Nueva Cantidad"
+msgstr "Nuevo Balance:"
 
 #. i18n: keyword: TXN_NOT_SUPPORTED
 msgid "Transaction Not Supported"
@@ -1927,11 +1927,11 @@ msgstr "El archivo que has seleccionado no está permitido. Por favor seleccione
 
 #. i18n: keyword: E_INVALID_SELECTED_FILE_SIZE
 msgid "The file you selected is too big. Please reduce the size to proceed with the upload."
-msgstr "El archivo que has seleccionado es muy grande. Por favor reduce el peso para poder subirlo"
+msgstr "El archivo que has seleccionado es muy grande. Por favor reduce el peso para poder subirlo."
 
 #. i18n: keyword: E_DID_NOT_AGREE_TO_HALLOWEEN_RULES
 msgid "Unfortunately, you can not participate in the Halloween event if you do not agree with the event rules."
-msgstr "Desafortunadamente, no puedes participar en el evento de Halloween si no estás de acuerdo con las reglas del evento"
+msgstr "Desafortunadamente, no puedes participar en el evento de Halloween si no estás de acuerdo con las reglas del evento."
 
 #. i18n: keyword: E_HALLOWEEN_USER_ALREADY_PARTICIPATED
 msgid "An administrator has already approved one of your submissions. You will receive a reward very soon. If you have not received anything after a couple of hours, please visit the <a href='/account/transactions'>transactions page</a> and contact support if necessary."

--- a/es-ES/strings.po
+++ b/es-ES/strings.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: klei-accounts\n"
 "Report-Msgid-Bugs-To: support@kleientertainment.com\n"
 "POT-Creation-Date: 2018-05-24 11:14-0700\n"
-"PO-Revision-Date: 2021-10-15 08:17-0700\n"
+"PO-Revision-Date: 2021-10-15 08:23-0700\n"
 "Last-Translator: Klei Entertainment <support@kleientertainment.com>\n"
 "Language-Team: Spanish (https://accounts.klei.com/community-translations)\n"
 "Language: es\n"
@@ -407,15 +407,15 @@ msgstr "El servicio de terceros que usamos para gestionar tu suscripción al bol
 
 #. i18n: keyword: LinkDiscordTitle
 msgid "Link Discord Account"
-msgstr ""
+msgstr "Vincular Cuenta de Discord"
 
 #. i18n: keyword: LinkDiscordDescription
 msgid "This will link your Discord Account to your Klei Account."
-msgstr ""
+msgstr "Esto vinculará tu cuenta de Discord a tu cuenta de Klei."
 
 #. i18n: keyword: UnlinkDiscordTitle
 msgid "Unlink Discord Account"
-msgstr ""
+msgstr "Desvincular Cuenta de Discord"
 
 #. i18n: keyword: MergeAccountTitle
 msgid "Merge An Account"
@@ -883,19 +883,19 @@ msgstr "Rareza"
 
 #. i18n: keyword: RollbackDialogConfirmation
 msgid "Are you sure you want to rollback this transaction?"
-msgstr ""
+msgstr "¿Estás seguro de querer revertir esta transacción?"
 
 #. i18n: keyword: RollbackDialogNotEnoughCurrency
 msgid "You don't have enough currency for this rollback! You need another"
-msgstr ""
+msgstr "¡Tu no tienes suficiente dinero para esta reversión! Necesitas otro"
 
 #. i18n: keyword: RollbackGain
 msgid "You will gain"
-msgstr ""
+msgstr "Tu obtendrás"
 
 #. i18n: keyword: RollbackLose
 msgid "You will lose"
-msgstr ""
+msgstr "Tu perderás"
 
 #. i18n: keyword: DownloadSettings
 msgid "Download Settings"
@@ -903,11 +903,11 @@ msgstr "Descargar Configuración"
 
 #. i18n: keyword: UpcomingBetasTitle
 msgid "Testing of Upcoming Projects"
-msgstr ""
+msgstr "Prueba de Proyectos Futuros"
 
 #. i18n: keyword: UpcomingBetasDescription
 msgid "You can register for testing alpha and beta projects in which you are interested. You will receive an email if you are accepted into one."
-msgstr ""
+msgstr "Tu puedes registrarte para probar proyectos en modo Alpha y Beta en los que estés interesado. Tu vas a recibir un correo electrónico si eres aceptado en un grupo de prueba."
 
 #. i18n: keyword: BetaStatus
 msgid "Status:"
@@ -1051,7 +1051,7 @@ msgstr "Suscríbete a nuestro boletín de noticias"
 
 #. i18n: keyword: RewardNameRedeemableCode
 msgid "Redeemable Code"
-msgstr ""
+msgstr "Código Redimible"
 
 #. i18n: keyword: RewardMessageFacebook
 msgid "<a href='https://www.facebook.com/kleientertainment/' target='_blank'>Follow us on Facebook</a> to claim this reward."
@@ -1099,7 +1099,7 @@ msgstr "Canjeo de Regalos"
 
 #. i18n: keyword: GiftRedemptionDescription
 msgid "Hello! It looks like you got an item key or gift code, would you like to redeem it now? Type in the code in the form below and we will grant you the item faster than you can blink <em>&mdash;unless you can blink very fast, in which case you should close your eyes for a few milliseconds&mdash;</em>"
-msgstr ""
+msgstr "Hola! Tal parece que tu tienes una llave o código de regalo, te gustaría redimirlo ahora? Escribe el código en el formulario de abajo y nosotros te entregaremos un artículo de regalo más rápido de lo que puedes parpadear <em>&mdash;a menos que puedas parpadear muy rápido, en cuyo caso deberías cerrar los ojos por unos milisegundos&mdash;</em>"
 
 #. i18n: keyword: GiftRedemptionCodeLabel
 msgid "Enter Your Code"
@@ -1331,7 +1331,7 @@ msgstr "El juego no existe."
 
 #. i18n: keyword: E_REWARD_REPLAYED
 msgid "This reward has already been claimed, your balances have been updated!"
-msgstr ""
+msgstr "Esta recompensa ya ha sido reclamada, ¡tus saldos han sido actualizados!"
 
 #. i18n: keyword: E_INTERNAL_SERVER_ERROR
 msgid "Internal server error, try again in a few seconds."
@@ -1595,7 +1595,7 @@ msgstr "Los servidores de Steam no están disponibles en este momento."
 
 #. i18n: keyword: E_STEAM_E502_L3
 msgid "Steam servers are unavailable at the moment. This usually happens during the first and second hours after a big sale. Please, contact the Steam customer support team for further assistance."
-msgstr ""
+msgstr "Los servidores de Steam no están disponibles en este momento. Esto suele suceder durante la primera y segunda hora después de una gran venta. Comuníquese con el equipo de atención al cliente de Steam para obtener más ayuda."
 
 #. i18n: keyword: E_STEAM_BROKEN_FEATURE_WARNING
 msgid "It appears you are viewing this web page using Steam In-Game Browser. Unfortunately, some features in this website do not work very well in this environment. If you have problems using this feature please consider using a regular web browser outside of Steam."
@@ -1747,11 +1747,11 @@ msgstr "Lo sentimos, pero esta recompensa ya no está activa. Síganos en las re
 
 #. i18n: keyword: E_DOUBLE_ROLLBACK
 msgid "This transaction has already been rolled back."
-msgstr ""
+msgstr "Esta transacción ya se ha revertida."
 
 #. i18n: keyword: E_UNSUPPORTED_FOR_ROLLBACK
 msgid "This transaction cannot be rolled back."
-msgstr ""
+msgstr "Esta transacción no se puede revertir."
 
 #. i18n: keyword: UserTransactions
 msgid "User Transactions"
@@ -1779,7 +1779,7 @@ msgstr "No hay transacciones."
 
 #. i18n: keyword: TransactionRollback
 msgid "Rollback"
-msgstr ""
+msgstr "Revertir"
 
 #. i18n: keyword: CurrentBalanceForSpools
 msgid "Current Spools Balance"
@@ -1847,7 +1847,7 @@ msgstr "Compra de Mercado"
 
 #. i18n: keyword: TXN_MARKET_ROLLBACK
 msgid "Market Rollback"
-msgstr ""
+msgstr "Reversión de Mercado"
 
 #. i18n: keyword: TXN_ITEM_TRADE_LOSE
 msgid "Item Trade Lose"
@@ -1895,11 +1895,11 @@ msgstr "Caja DLC de Steam"
 
 #. i18n: keyword: TXN_CURRENCY_EXCHANGE
 msgid "Currency Exchange"
-msgstr ""
+msgstr "Cambio de Moneda"
 
 #. i18n: keyword: TXN_CONSUME_REDEEMABLE_CODE
 msgid "Consume Redeemable Code"
-msgstr ""
+msgstr "Consumo de Código Canjeable"
 
 #. i18n: keyword: Marketable
 msgid "Marketable"


### PR DESCRIPTION
## Minor grammar and punctuation corrections in the Spanish translation

Thanks to [Poedit](https://poedit.net), I was able to identify a couple of mistranslations, grammar mistakes, and missing punctuations in some keywords. While I didn’t check every single existing translation, these changes should be enough to clarify a few elements in the user interface.

## Translate a few keywords in the Spanish translation file

Adding translations to new keywords, especially the ones used in the Discord integration.

## Add homonyms to the Spanish translation to complement some keywords

While the underlaying library accepts empty translations by recycling the original (English) text, homonyms still need to be translated according to the PO file format. Crowdin will probably re-delete these translations since they look the same as the original text, but having some consistency may be good. Feel free to revert [this specific commit](https://github.com/kleientertainment/KleiAccountsLocale/commit/864d391cc2b193cca8aca131d96db494bb271e77) if you consider homonyms unnecessary.