### PR TITLE
Update zh-CN strings.po

### DIFF
--- a/zh-CN/strings.po
+++ b/zh-CN/strings.po
@@ -1307,15 +1307,15 @@ msgstr "连接Steam失败"
 
 #. i18n: keyword: RevertAccountLimboTitle
 msgid "Account marked for deletion with User ID:"
-msgstr ""
+msgstr "为以下用户ID的账户已被标记为待删除："
 
 #. i18n: keyword: RevertAccountLimboDescription
 msgid "Your account has been marked for deletion and will be permanently unrecoverable within 30 days.<br>If you would like to recover your account, please press the \"Recover Account\" button."
-msgstr ""
+msgstr "您的账户已被标记为待删除，并且将在30日内变为永久无法恢复状态。<br>如果您希望恢复您的账户，请点击\"恢复账户\"按钮。"
 
 #. i18n: keyword: RevertAccountLimboConfirm
 msgid "Recover Account"
-msgstr ""
+msgstr "恢复账户"
 
 #. i18n: keyword: E_JSON_BAD_EOF
 msgid "The server was unable to read the data you submitted. Please try again later."
@@ -1795,11 +1795,11 @@ msgstr "回滚"
 
 #. i18n: keyword: GiftingEventWeek
 msgid "Week"
-msgstr ""
+msgstr "周"
 
 #. i18n: keyword: GiftingEventGift
 msgid "Gift"
-msgstr ""
+msgstr "礼物"
 
 #. i18n: keyword: CurrentBalanceForSpools
 msgid "Current Spools Balance"
@@ -1923,11 +1923,11 @@ msgstr "使用兑换码"
 
 #. i18n: keyword: TXN_SUPPORT_ISSUED_CURRENCY
 msgid "Klei Support Issued Currency"
-msgstr ""
+msgstr "Klei客服发出的货币"
 
 #. i18n: keyword: TXN_SUPPORT_ISSUED_ITEM
 msgid "Klei Support Issued Item"
-msgstr ""
+msgstr "Klei客服发出的道具"
 
 #. i18n: keyword: Marketable
 msgid "Marketable"


### PR DESCRIPTION
I personally suggest using a variable in "Account marked for deletion with User ID:" to represent the User ID, since elements in this sentence has to be re-arranged for a natural translation.

e.g. (line: 1309 - 1310)
msgid "Account marked for deletion with User ID: {{.UID}}"
msgstr "用户ID为{{.UID}}的账户已被标记为待删除"