### PR TITLE
Removes duplicate RewardBolts msgid

### DIFF
--- a/be/strings.po
+++ b/be/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/de/strings.po
+++ b/de/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/es-ES/strings.po
+++ b/es-ES/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/fr/strings.po
+++ b/fr/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/pl-PL/strings.po
+++ b/pl-PL/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/pt-BR/strings.po
+++ b/pt-BR/strings.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: klei-accounts\n"
 "Report-Msgid-Bugs-To: support@kleientertainment.com\n"
 "POT-Creation-Date: 2018-05-24 11:14-0700\n"
-"PO-Revision-Date: 2022-02-15 22:12-0300\n"
+"PO-Revision-Date: 2022-02-25 23:33-0300\n"
 "Last-Translator: Mateus Generoso (mtsgeneroso)\n"
 "Language-Team: Portuguese, Brazilian (https://accounts.klei.com/community-translations)\n"
 "Language: pt\n"
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: pt-BR\n"
 "X-Crowdin-File: strings.po\n"
 "X-Crowdin-File-ID: 76\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. i18n: keyword: Email
 msgid "E-mail"
@@ -1129,10 +1130,6 @@ msgstr "Validação do Código de Presente"
 msgid "Use this page to check if your gift code is valid and has not been redeemed yet. This will NOT redeem the gift code. "
 msgstr "Use esta página para verificar se seu código de presente é válido e se ainda não foi resgatado. Esta ação NÃO resgatará o código de presente. "
 
-#. i18n: keyword: ValidateGiftCodeLabel
-msgid "Enter Your Code"
-msgstr ""
-
 #. i18n: keyword: ValidateGiftSubmitButton
 msgid "Validate Code"
 msgstr "Código de Validação"
@@ -1927,11 +1924,11 @@ msgstr "Drops da Twitch"
 
 #. i18n: keyword: TXN_DOUYU_ITEM_DROP
 msgid "Douyu Item Drop"
-msgstr ""
+msgstr "Drops do Douyu"
 
 #. i18n: keyword: TXN_BILIBILI_ITEM_DROP
 msgid "Bilibili Item Drop"
-msgstr ""
+msgstr "Drops do Bilibili"
 
 #. i18n: keyword: TXN_DAILY_GIFT_ITEM
 msgid "Daily Gift Item"

--- a/pt-BR/strings.po
+++ b/pt-BR/strings.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: klei-accounts\n"
 "Report-Msgid-Bugs-To: support@kleientertainment.com\n"
 "POT-Creation-Date: 2018-05-24 11:14-0700\n"
-"PO-Revision-Date: 2022-02-25 23:33-0300\n"
+"PO-Revision-Date: 2022-04-13 14:56-0300\n"
 "Last-Translator: Mateus Generoso (mtsgeneroso)\n"
 "Language-Team: Portuguese, Brazilian (https://accounts.klei.com/community-translations)\n"
 "Language: pt\n"
@@ -984,35 +984,35 @@ msgstr "Alternativa"
 
 #. i18n: keyword: RewardPoints
 msgid "Klei Points"
-msgstr ""
+msgstr "Pontos Klei"
 
 #. i18n: keyword: RewardSpools
 msgid "Spools"
-msgstr ""
+msgstr "Carretéis"
 
 #. i18n: keyword: RewardBolts
 msgid "Bolts of Cloth"
-msgstr ""
+msgstr "Parafusos de Tecido"
 
 #. i18n: keyword: RewardNintendoBolts
 msgid "Bolts of Cloth"
-msgstr ""
+msgstr "Parafusos de Tecido"
 
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
-msgstr ""
+msgstr "<b>Pontos Klei</b><br>Os pontos Klei são utilizados para resgatar conquistas dentro do jogo na página de recompensas da Klei."
 
 #. i18n: keyword: RewardSpoolsGlossary
 msgid "<b>Spools</b><br>Spools are used to weave items in the Curio Cabinet in-game."
-msgstr ""
+msgstr "<b>Carretéis</b><br>Os carretéis são utilizados para tecer os itens no Armário Curio dentro do jogo."
 
 #. i18n: keyword: RewardBoltsGlossary
 msgid "<b>Bolts of Cloth</b><br>(PlayStation and XBox only) In-game currency used to purchase skins and bundles from the in-game store."
-msgstr ""
+msgstr "<b>Parafusos de Tecido</b><br>(Apenas PlayStation e XBox) Moeda utilizada dentro jogo para comprar skins e pacotes da loja."
 
 #. i18n: keyword: RewardNintendoBoltsGlossary
 msgid "<b>Bolts of Cloth</b><br>(Nintendo Switch Only) In-game currency used to purchase skins and bundles from the in-game store."
-msgstr ""
+msgstr "<b>Parafusos de Tecido</b><br>(Apenas Nintendo Switch) Moeda utilizada dentro do jogo para comprar skins e pacotes da loja."
 
 #. i18n: keyword: RewardPointsAbbreviation
 msgid "pts"
@@ -2077,3 +2077,4 @@ msgstr "O banimento em sua conta não é reversível."
 #. i18n: keyword: E_INVALID_GOTO_URL
 msgid "Oh no! It looks like you clicked a broken link. You might need to authenticate again."
 msgstr "Ah não! Parece que você clicou em um link quebrado. Pode ser necessário autenticar-se novamente."
+

--- a/pt-BR/strings.po
+++ b/pt-BR/strings.po
@@ -994,10 +994,6 @@ msgstr "Carretéis"
 msgid "Bolts of Cloth"
 msgstr "Parafusos de Tecido"
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr "Parafusos de Tecido"
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr "<b>Pontos Klei</b><br>Os pontos Klei são utilizados para resgatar conquistas dentro do jogo na página de recompensas da Klei."

--- a/ru/strings.po
+++ b/ru/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/strings.po
+++ b/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/tr/strings.po
+++ b/tr/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/uk/strings.po
+++ b/uk/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/vi/strings.po
+++ b/vi/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/zh-CN/strings.po
+++ b/zh-CN/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""

--- a/zh-TW/strings.po
+++ b/zh-TW/strings.po
@@ -993,10 +993,6 @@ msgstr ""
 msgid "Bolts of Cloth"
 msgstr ""
 
-#. i18n: keyword: RewardNintendoBolts
-msgid "Bolts of Cloth"
-msgstr ""
-
 #. i18n: keyword: RewardPointsGlossary
 msgid "<b>Klei Points</b><br>Klei points are used to redeem in-game rewards from the Klei Rewards page."
 msgstr ""


### PR DESCRIPTION
Line 993 and 997 have the same msgid. This fix removes the msgid from line 997 of all .po files.